### PR TITLE
Add missing package import of SocialAuthMutation

### DIFF
--- a/graphql_social_auth/__init__.py
+++ b/graphql_social_auth/__init__.py
@@ -1,5 +1,5 @@
 from . import relay
-from .mutations import SocialAuth, SocialAuthJWT
+from .mutations import SocialAuthMutation, SocialAuth, SocialAuthJWT
 
 __all__ = ['relay', 'SocialAuthMutation', 'SocialAuth', 'SocialAuthJWT']
 


### PR DESCRIPTION
This seems to have been missed in 1bd14126, which adds `SocialAuthMutation` to the `__all__` of `graphql_social_auth/__init__.py`, but not to the actual import list.