### PR TITLE
.gitignore: Add .pytest_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__
 
 *.egg*
 .cache
+.pytest_cache
 .coverage
 .tox
 


### PR DESCRIPTION
This is pytest's newer default cache directory.