### PR TITLE
Add missing package import of `relay.SocialAuthMutation`

### DIFF
--- a/graphql_social_auth/__init__.py
+++ b/graphql_social_auth/__init__.py
@@ -1,5 +1,5 @@
 from . import relay
-from .mutations import SocialAuthMutation, SocialAuth, SocialAuthJWT
+from .mutations import SocialAuth, SocialAuthJWT, SocialAuthMutation
 
 __all__ = ['relay', 'SocialAuthMutation', 'SocialAuth', 'SocialAuthJWT']
 

--- a/graphql_social_auth/mixins.py
+++ b/graphql_social_auth/mixins.py
@@ -29,6 +29,6 @@ class JSONWebTokenMixin:
         except ImportError:
             raise ImportError(
                 'django-graphql-jwt not installed.\n'
-                'Use `pip install \'django-graphql-social-auth[jwt]\'`.')
+                "Use `pip install 'django-graphql-social-auth[jwt]'`.")
 
         return cls(token=get_token(social.user))

--- a/graphql_social_auth/relay/__init__.py
+++ b/graphql_social_auth/relay/__init__.py
@@ -1,3 +1,3 @@
-from .mutations import SocialAuthMutation, SocialAuth, SocialAuthJWT
+from .mutations import SocialAuth, SocialAuthJWT, SocialAuthMutation
 
 __all__ = ['SocialAuthMutation', 'SocialAuth', 'SocialAuthJWT']

--- a/graphql_social_auth/relay/__init__.py
+++ b/graphql_social_auth/relay/__init__.py
@@ -1,3 +1,3 @@
-from .mutations import SocialAuth, SocialAuthJWT
+from .mutations import SocialAuthMutation, SocialAuth, SocialAuthJWT
 
 __all__ = ['SocialAuthMutation', 'SocialAuth', 'SocialAuthJWT']

--- a/graphql_social_auth/relay/mutations.py
+++ b/graphql_social_auth/relay/mutations.py
@@ -1,8 +1,8 @@
 import graphene
 
-from . import nodes
 from .. import mixins, mutations
 from ..decorators import social_auth
+from . import nodes
 
 
 class SocialAuthMutation(mixins.SocialAuthMixin,


### PR DESCRIPTION
Fixes an issue whereby `graphql_social_auth.relay.SocialAuthMutation` cannot be imported for use when customising `SocialAuth` behaviour, [`as documented in the README`](https://github.com/flavors/django-graphql-social-auth#customizing).

The issue stems from 1bd1412, which adds `SocialAuthMutation` to `__all__` in `graphql_social_auth/relay/__init__.py`, but not to the import list itself.

Same rationale as PR #4, but for the `relay` module.